### PR TITLE
Add rss feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,9 @@
 paginate: 5
 paginate_path: "page:num"
-gems: [jekyll-paginate]
+gems:
+  - jekyll-paginate
+  - jekyll-feed
+title: adrian's soapbox
 url: https://flafla2.github.io
 defaults:
   -

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,6 +6,7 @@
 
 		<link rel="stylesheet" type="text/css" href="/css/all.css" />
 		<link rel="stylesheet" type="text/css" href="/css/syntax.css" />
+		<link rel="alternate" type="application/rss+xml" href="/feed.xml" title="{{ site.title | escape }}" />
 		<script defer src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 		<script defer type="text/javascript" src="/js/all.js"></script>
 		<script defer type"text/javascript" src="https://assets.gfycat.com/gfycat.js"></script>


### PR DESCRIPTION
* The jekyll-feed plugin was already installed via github-pages. I have enabled it in the Jekyll config.

* Added a site title to the Jekyll config as well, so that the feed carries the same name as the home page.

* Added it to the header so that feed readers pick it up automatically when entering a link to the home page or a post.